### PR TITLE
style: スクロールトップのcss変更, docs: aboutをi18nに変更

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -89,7 +89,7 @@ h3 {
 }
 .overlay {
   background-color: rgba(255, 255, 255, 0.772);
-  padding: 5px 40px;
+  padding: 5px 40px 8px 40px;
 }
 .subcolor-b {
   border-bottom: 1px solid hsla(7, 69%, 90%, 0.7);
@@ -146,4 +146,19 @@ a:hover {
 }
 .uk-select {
   text-align: center;
+}
+@media (min-width: 960px) {
+  .margin-r100\@m {
+    margin-right: 100px;
+  }
+}
+@media (max-width: 959px) {
+  .margin-r20\@95 {
+    margin-right: 20px;
+  }
+}
+.scroll-top {
+  padding: 1px 4px 8px 4px;
+  border-radius: 1%;
+  background-color: rgba(255, 255, 255, 0.7);
 }

--- a/app/assets/stylesheets/picture.css
+++ b/app/assets/stylesheets/picture.css
@@ -15,11 +15,6 @@
   font-weight: 350;
 }
 /* アイコンを目立たさるための囲い部分 */
-.scroll-top {
-  background-color: rgba(255, 255, 255, 0.7);
-  padding: 13px 10px;
-}
-/* アイコンを目立たさるための囲い部分 */
 .slide-nav {
   background-color: rgba(255, 255, 255, 0.7);
   padding: 9px 13px;
@@ -59,4 +54,7 @@
   .f-size-13 {
     font-size: 13px;
   }
+}
+.margin-x-auto {
+  margin: 0 auto;
 }

--- a/app/assets/stylesheets/static_pages.css
+++ b/app/assets/stylesheets/static_pages.css
@@ -26,3 +26,6 @@
 .sub-color-b {
   border: 1px solid #f7d7d3b2;
 }
+.padding-t {
+  padding-top: 6px;
+}

--- a/app/views/kaminari/uikit/_paginator.html.erb
+++ b/app/views/kaminari/uikit/_paginator.html.erb
@@ -7,7 +7,7 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>
-  <nav class="pagination uk-margin-xlarge-right" role="navigation" aria-label="pager Pagination">
+  <nav class="pagination" role="navigation" aria-label="pager Pagination">
     <div class='uk-overlay uk-overlay-default uk-border-rounded'>
     <ul class="uk-pagination uk-flex-center" uk-margin>
     <%= prev_page_tag unless current_page.first? %>

--- a/app/views/pictures/daily_pictures.html.erb
+++ b/app/views/pictures/daily_pictures.html.erb
@@ -11,7 +11,11 @@
     </div>
   <% end %>
 </div>
-<div class="uk-flex uk-flex-middle">
-  <%= paginate @pictures, theme: 'uikit', left: 2, right: 2 %>
-  <a href="#" uk-totop uk-scroll class="pagination scroll-top uk-box-shadow-small uk-border-circle"></a>
+<div class="uk-width1-1 uk-flex uk-flex-center uk-flex-middle">
+  <div class="margin-x-auto">
+    <%= paginate @pictures, theme: 'uikit', left: 2, right: 2 %>
+  </div>
+  <div class="margin-r100@m margin-r20@95 scroll-top subcolor-b">
+    <a href="#" uk-totop uk-scroll class="pagination"></a>
+  </div>
 </div>

--- a/app/views/pictures/index.html.erb
+++ b/app/views/pictures/index.html.erb
@@ -6,7 +6,11 @@
     <%= render partial: 'picture', collection: @pictures, as: :picture, locals: { from: 'index' } %>
   </div>
 </div>
-<div class="uk-flex uk-flex-middle">
-  <%= paginate @pictures, theme: 'uikit', left: 2, right: 2 %>
-  <a href="#" uk-totop uk-scroll class="pagination scroll-top uk-box-shadow-small uk-border-circle"></a>
+<div class="uk-width1-1 uk-flex uk-flex-center uk-flex-middle">
+  <div class="margin-x-auto">
+    <%= paginate @pictures, theme: 'uikit', left: 2, right: 2 %>
+  </div>
+  <div class="margin-r100@m margin-r20@95 scroll-top subcolor-b">
+    <a href="#" uk-totop uk-scroll class="pagination"></a>
+  </div>
 </div>

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -1,17 +1,27 @@
-<h1 class="uk-border-rounded overlay mix-b">今日は何の日？</h1>
+<h1 class="uk-border-rounded overlay mix-b"><%= t ".title" %></h1>
 <div class="uk-margin overlay sub-color-b uk-border-rounded relative">
-  <p class="uk-margin-top">今日は何の日？は思い出を振り返るアプリです</p>
-  <p>保存した写真を撮影日で分類し、その日と同じ日の、全ての年の写真を表示するので
-  <br>何年前に何があったか？がパッとわかるようになります</p>
-  <p>過去の今日を思い返して、また新たな思い出のきっかけになれたらと思います</p>
+  <p class="uk-margin-top"><%= t ".look_back_on_memories" %></p>
+  <p><%= t ".photos_sorted_date" %>
+  <br><%= t ".quick_easy_find" %></p>
+  <p><%= t ".will_trigger_new_memories" %></p>
   <%= image_tag 'mobile.png', class: 'mobile-icon' %>
 </div>
 
 <div class="uk-margin overlay uk-width-2xlarge sub-color-b uk-border-rounded relative">
   <%= image_tag 'camera.png', class: 'camera-icon' %>
-  <h3 class="uk-flex uk-flex-center uk-margin-top">使い方</h3>
-  <p>新規写真登録をすると、「同じ日の思い出」ページで今日と同じ日の写真を表示します</p>
-  <p>今日と同じ日の写真がなかった場合、同じ月の写真が表示されます</p>
+  <h3 class="uk-flex uk-flex-center uk-margin-top"><%= t ".how_use" %></h3>
+  <p><%= t ".display_same_day_as_today" %></p>
+  <p><%= t ".or_same_month_displayed" %></p>
   <%= video_tag '/videos/同じ日の思い出demo.mp4', playsinline: true, controls: true, class: 'uk-margin' %>
-  <p>保存した全ての写真を見たい時は「保存済み写真一覧」から確認できます</p>
+  <p><%= t ".saved_all_photos_list" %></p>
+</div>
+<div class="uk-margin-auto-left uk-flex uk-text-small">
+  <% unless logged_in? %>
+    <%= link_to t('link.user_create'), new_user_path, class: 'padding-t' %>
+    <span class="padding-t">　/　</span>
+    <%= link_to t('link.login'), login_path, class: 'padding-t uk-margin-right' %>
+  <% end %>
+  <div class="margin-r100@m margin-r20@95 scroll-top subcolor-b">
+    <a href="#" uk-totop uk-scroll class="pagination"></a>
+  </div>
 </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,7 +1,7 @@
 <%= render 'shared/flash_message' %>
-<h1 class="uk-border-rounded uk-padding"><%= t ".title" %></h1>
-<%= link_to auth_at_provider_path(provider: :google) do %>
-  <%= image_tag('web_light_sq_SI@1x.png', alt: 'Google sign in', class: 'uk-margin') %>
+<h1 class="uk-border-rounded overlay subcolor-b uk-margin-top"><%= t ".title" %></h1>
+<%= link_to auth_at_provider_path(provider: :google), class:'uk-margin' do %>
+  <%= image_tag('web_light_sq_SI@1x.png', alt: 'Google sign in') %>
 <% end %>
 
 <div class="uk-padding line-div"><%= t'users.new.or' %></div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,10 +1,8 @@
 <%= render 'shared/flash_message' %>
-<h1 class="uk-border-rounded uk-padding"><%= t ".title" %></h1>
-<%= link_to auth_at_provider_path(provider: :google) do %>
-  <%= image_tag('web_light_sq_SI@1x.png', alt: 'Google sign in', class: 'uk-margin') %>
+<h1 class="uk-border-rounded overlay subcolor-b uk-margin-top"><%= t ".title" %></h1>
+<%= link_to auth_at_provider_path(provider: :google), class:'uk-margin' do %>
+  <%= image_tag('web_light_sq_SI@1x.png', alt: 'Google sign in') %>
 <% end %>
-
-
 <div class="uk-padding line-div"><%= t'.or' %></div>
 
 <%= render 'form' %>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -19,9 +19,20 @@ ja:
     privacy_policy: プライバシーポリシー
     contact: お問い合わせ
     cancel: キャンセル
+  static_pages:
+    about:
+      title: 今日は何の日？
+      look_back_on_memories: 今日は何の日？は思い出を振り返るアプリです
+      photos_sorted_date: 保存した写真を撮影日で分類し、その日と同じ日の、全ての年の写真を表示するので
+      quick_easy_find: 何年前に何があったか？がパッとわかるようになります
+      will_trigger_new_memories: 過去の今日を思い返して、また新たな思い出のきっかけになれたらと思います
+      how_use: 使い方
+      display_same_day_as_today: 新規写真登録をすると、「同じ日の思い出」ページで今日と同じ日の写真を表示します
+      or_same_month_displayed: 今日と同じ日の写真がなかった場合、同じ月の写真が表示されます
+      saved_all_photos_list: 保存した全ての写真を見たい時は「保存済み写真一覧」から確認できます
   users:
     new:
-      title: ユーザー新規登録
+      title: 新規会員登録
       or: または
   user_sessions:
     new:


### PR DESCRIPTION
スクロールトップの見た目変更と再整列
about画面での未ログイン時の「新規登録」と「ログイン」のリンク追加
新規登録、ログインタイトルのcss統一
about画面の概要をi18nに変更


