### PR TITLE
feat:ユーザー削除機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,10 +4,19 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
   before_action :require_login
+  before_action :set_user
 
   private
 
   def not_authenticated
     redirect_to login_path, danger: t('flash.please_login')
+  end
+
+  def set_user
+    @user = current_user if logged_in?
+  end
+
+  def clear_pictures_from_session
+    session.delete(:pictures_by_year)
   end
 end

--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -32,7 +32,7 @@ class PicturesController < ApplicationController
     if process_images(user_checksums)
       redirect_to daily_pictures_pictures_path, success: t('flash.picture_create')
     else
-      flash.now[:error] = t('flash.picture_failed')
+      flash.now[:danger] = t('flash.picture_failed')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,5 +3,7 @@
 # controllers/static_pages_controller.rb
 class StaticPagesController < ApplicationController
   skip_before_action :require_login
-  def about; end
+  def about
+    @user = current_user
+  end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -22,10 +22,4 @@ class UserSessionsController < ApplicationController
     logout
     redirect_to root_path, status: :see_other, success: t('flash.logout')
   end
-
-  private
-
-  def clear_pictures_from_session
-    session.delete(:pictures_by_year)
-  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,8 @@
 # controllers/users_controller.rb
 class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
+  before_action :clear_pictures_from_session, only: [:destroy]
+
   def new
     @user = User.new
   end
@@ -16,6 +18,15 @@ class UsersController < ApplicationController
     else
       flash.now[:danger] = t('flash.user_failed')
       render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @user = User.find(params[:id])
+    if @user == current_user
+      @user.destroy!
+      reset_session
+      redirect_to root_path, success: t('flash.user_destroy')
     end
   end
 

--- a/app/views/pictures/daily_pictures.html.erb
+++ b/app/views/pictures/daily_pictures.html.erb
@@ -1,7 +1,7 @@
+<%= render 'shared/flash_message' %>
 <% if @title != nil %>
 <h1 class="uk-border-rounded overlay subcolor-b uk-margin-top"><%= @title %></h1>
 <% end %>
-<%= render 'shared/flash_message' %>
 <%= render 'search_form', form_url: daily_pictures_pictures_path %>
 <div class="uk-width-1-1">
   <% @pictures_by_year.each do |year, pictures| %>

--- a/app/views/pictures/index.html.erb
+++ b/app/views/pictures/index.html.erb
@@ -1,5 +1,5 @@
-<h1 class="uk-border-rounded overlay subcolor-b"><%= t ".title" %></h1>
 <%= render 'shared/flash_message' %>
+<h1 class="uk-border-rounded overlay subcolor-b"><%= t ".title" %></h1>
 <%= render 'search_form', form_url: pictures_path %>
 <div class="uk-width-1-1">
   <div class="uk-child-width-1-2 uk-child-width-1-4@m" uk-grid="masonry: pack">

--- a/app/views/pictures/new.html.erb
+++ b/app/views/pictures/new.html.erb
@@ -1,3 +1,4 @@
+<%= render 'shared/flash_message' %>
 <h1 class="uk-border-rounded overlay subcolor-b"><%= t'.title' %></h1>
 <ul class='uk-list uk-width-large uk-margin-large'>
   <li><%= t('.select_multiple') %></li>
@@ -6,7 +7,6 @@
   <li><%= t('.png_date') %></li>
 </ul>
 
-<%= render 'shared/flash_message' %>
 <%= form_with(model: @picture, url: pictures_path, local: true) do |f| %>
 <%= render 'shared/error_messages', object: f.object %>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,6 +21,9 @@
               <li>
                 <%= link_to t('link.logout'), logout_path, data: { turbo_method: :delete} %>
               </li>
+              <li class="uk-margin-small-top">
+                <%= link_to t('link.user_delete'), user_path(@user), data: { turbo_method: :delete, turbo_confirm: t('helpers.user_delete_confirm')} %>
+              </li>
             </ul>
           </div>
         <% else %>

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -1,3 +1,4 @@
+<%= render 'shared/flash_message' %>
 <h1 class="uk-border-rounded overlay mix-b"><%= t ".title" %></h1>
 <div class="uk-margin overlay sub-color-b uk-border-rounded relative">
   <p class="uk-margin-top"><%= t ".look_back_on_memories" %></p>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -7,9 +7,11 @@ ja:
       login: ログイン
       search: 検索
     picture_delete_confirm: 「画像」を削除します。よろしいですか？
+    user_delete_confirm: ユーザー削除します。よろしいですか？
   link:
     home: 今日は何の日？
     user_create: 新規登録
+    user_delete: 退会する
     login: ログイン
     logout: ログアウト
     new_picture: 新規写真登録
@@ -59,8 +61,9 @@ ja:
     login: ログインしました
     login_failed: メールアドレスまたはパスワードが間違っています
     logout: ログアウトしました
-    user_create: ユーザー登録が完了しました
+    user_create: 新規会員登録が完了しました
     user_failed: ユーザー登録に失敗しました
+    user_destroy: 退会しました
     google_login: Googleアカウントでログインしました
     google_failed: Googleアカウントでのログインに失敗しました
     please_login: ログインしてください

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ('/')
   root 'static_pages#about'
-  resources :users, only: %i[new create]
+  resources :users, only: %i[new create destroy]
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'


### PR DESCRIPTION
ユーザー削除機能をヘッダーのドロップナビゲーションに追加
routes, user_controllerのアクション, viewでのlink_toを追加
ヘッダーにリンクを表示しているため、@userをログインしている時で限定しapplication_controllerで実装
ログアウトで設定していた、session削除をuser_destroyでも実行するようにメソッドを
user_session_contorollerからapplication_controllerに移行