### PR TITLE
feat: pageモデルを作成

### DIFF
--- a/app/assets/stylesheets/album.css
+++ b/app/assets/stylesheets/album.css
@@ -1,0 +1,16 @@
+@media (min-width: 495px) {
+  .flex-bottom\@49 {
+    display: flex;
+    align-items: end;
+  }
+}
+.cancel-margin {
+  display: flex;
+  justify-content: end;
+  padding-right: 12px;
+}
+@media (min-width: 495px) {
+  .cancel-margin {
+    width: auto;
+  }
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -186,3 +186,8 @@ a:hover {
 .mb-34 {
   margin-bottom: 34px;
 }
+@media (min-width: 1200px) {
+  .mb-34 {
+    margin-bottom: 44px;
+  }
+}

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -1,5 +1,5 @@
 class AlbumsController < ApplicationController
-  before_action :set_album, only: %i[show edit update destroy edit_cancel]
+  before_action :set_album, only: %i[edit update destroy edit_cancel]
 
   def index
     @albums = current_user.albums.all
@@ -7,7 +7,11 @@ class AlbumsController < ApplicationController
     @album = Album.new
   end
 
-  def show;end
+  def show
+    @album = current_user.albums.includes(:pages).find(params[:id])
+    @pages = @album.pages
+    @page = Page.new
+  end
 
   def edit;end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,48 @@
+class PagesController < ApplicationController
+  before_action :set_album, only: %i[create]
+  before_action :set_page, only: %i[show edit update destroy]
+
+  def create
+    @page = @album.pages.build
+    last_page_number = @album.pages.maximum(:page_number)
+    # アルバムの最後のページ番号を取得
+    @page.page_number = last_page_number + 1
+
+    if @page.save
+      redirect_to page_path(@page), success: t('flash.page_create')
+    else
+      flash.now[:danger] = t('flash.page_failed')
+      render album_path(@album), status: :unprocessable_entity
+    end
+  end
+
+  def show;end
+
+  def edit;end
+
+  def update
+    if @page.update
+      redirect_to @page, success: t('flash.page_update')
+    else
+      flash.now[:danger] = t('flash.page_update_failed')
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    album_id = @page.album_id
+    @page.destroy
+    redirect_to album_path(album_id), success: t('flash.page_destroy')
+  end
+
+  private
+
+  def set_album
+    @album = current_user.albums.find(params[:album_id])
+  end
+
+  def set_page
+    @page = Page.find(params[:id])
+  end
+
+end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,14 @@
 class Album < ApplicationRecord
   belongs_to :user
+  has_many :pages, dependent: :destroy
+  after_create :create_initial_page
+
   validates :title, presence: true, length: { maximum: 50 }
   validates :is_sample, inclusion: { in: [true, false] }
+
+  private
+
+  def create_initial_page
+    pages.create(page_number: 1)
+  end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,0 +1,7 @@
+class Page < ApplicationRecord
+  belongs_to :album
+
+  validates :page_number, presence: true
+  validates :is_sample, inclusion: { in: [true, false] }
+  validates :album_id, uniqueness: { scope: :page_number }
+end

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -16,7 +16,7 @@ class Picture < ApplicationRecord
   validate :image_size
   validate :image_attached
 
-  before_save :shooting_date_set, if: :new_record?
+  before_create :shooting_date_set
 
   scope :checksums, -> { joins(image_attachment: :blob) }
   scope :allyears_on_same_date, lambda {

--- a/app/views/albums/edit.turbo_stream.erb
+++ b/app/views/albums/edit.turbo_stream.erb
@@ -2,9 +2,9 @@
 <%= turbo_stream.update 'error_explanation', partial: 'shared/error_messages', locals: { object: @album } %>
 
 <%= turbo_stream.replace dom_id(@album) do %>
-<div id="<%= dom_id(@album, :edit) %>" class="uk-flex uk-flex-bottom">
+<div id="<%= dom_id(@album, :edit) %>" class="flex-bottom@49">
   <%= render 'form', album: @album %>
-  <div class="mb-34">
+  <div class="mb-34 cancel-margin">
     <%= link_to t('link.cancel'), edit_cancel_album_path(@album), data: { turbo_stream: true }, class: 'paddig-y4x15 uk-text-small uk-border-rounded uk-button uk-button-default uk-button-small white-background-button' %>
   </div>
 </div>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,1 +1,13 @@
-<%= @album.title  %>
+<%= render 'shared/flash_message' %>
+<h1 class="uk-border-rounded overlay subcolor-b"><%= @album.title  %></h1>
+
+<%= link_to t('.new_page'), album_pages_path(@album), data: { "turbo-method": :post }, class: 'uk-margin' %>
+
+<% @pages.each do |page| %>
+  <div class="uk-flex uk-flex-bottom uk-margin">
+    <%= link_to page.page_number, page_path(page) %>
+    <div class="uk-margin-left">
+      <%= link_to "", page_path(page), data: { turbo_method: :delete, turbo_confirm: t('helpers.page_delete_confirm') }, class: "uk-icon-link", "uk-icon" => "trash" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,0 +1,4 @@
+<%= render 'shared/flash_message' %>
+<div class="uk-width-expand white-background">
+<%= @page.page_number %>
+</div>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -10,6 +10,7 @@ ja:
     picture_delete_confirm: 「画像」を削除します。よろしいですか？
     user_delete_confirm: ユーザー削除します。よろしいですか？
     album_delete_confirm: アルバムを削除します。よろしいですか？
+    page_delete_confirm: ページを削除します。よろしいですか？
   link:
     home: 今日は何の日？
     user_create: 新規登録
@@ -64,6 +65,8 @@ ja:
     index:
       title: アルバム一覧
       album_name: アルバム名
+    show:
+      new_page: 新規ページ作成
   flash:
     login: ログインしました
     login_failed: メールアドレスまたはパスワードが間違っています
@@ -83,6 +86,11 @@ ja:
     album_update: アルバムを更新しました
     album_update_failed: アルバムの更新に失敗しました
     album_destroy: アルバムを削除しました
+    page_create: ページを作成しました
+    page_failed: ページの作成に失敗しました
+    page_update: ページを更新しました
+    page_update_failed: ページの更新に失敗しました
+    page_destroy: ページを削除しました
   validate:
     image_type: JPEG か PNGファイルのみアップロード可能です
     image_size: 画像サイズは4MBまでです

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,5 +27,6 @@ Rails.application.routes.draw do
 
   resources :albums, only: %i[index show edit create update destroy] do
     get 'edit_cancel', on: :member
+    resources :pages, only: %i[show edit create update destroy], shallow: true
   end
 end

--- a/db/migrate/20240614101458_create_pages.rb
+++ b/db/migrate/20240614101458_create_pages.rb
@@ -1,0 +1,14 @@
+class CreatePages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :pages do |t|
+      t.references :album, null: false, foreign_key: true
+      t.integer :page_number, null: false
+      t.boolean :is_sample, null: false, default: false
+
+      t.timestamps
+    end
+
+    # album_idとpage_numberの組み合わせに一意性制約を追加
+    add_index :pages, [:album_id, :page_number], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_13_091528) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_14_101458) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_091528) do
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
   end
 
+  create_table "pages", force: :cascade do |t|
+    t.bigint "album_id", null: false
+    t.integer "page_number", null: false
+    t.boolean "is_sample", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["album_id", "page_number"], name: "index_pages_on_album_id_and_page_number", unique: true
+    t.index ["album_id"], name: "index_pages_on_album_id"
+  end
+
   create_table "pictures", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "title"
@@ -85,5 +95,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_091528) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "albums", "users"
+  add_foreign_key "pages", "albums"
   add_foreign_key "pictures", "users"
 end


### PR DESCRIPTION
pageモデル、テーブル、routes、crudコントローラ、viewを作成
albumモデルとリレーションを設定
album#showでpage一覧を表示
album#showでpage#createのリンクを表示
album#showでpage#destroyのリンクを表示
album#create時に、pageを1つ紐付けて作成するように変更
page#create時に、album_idでの1番最後のpage番号を取得し、その後ろにpageを付与するようにしている
